### PR TITLE
:zap: Fix chain synchronization for cross-chain transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ CLAUDE.md
 .playwright-mcp/*
 .codex/*
 plans-and-progress/*
+issues/*

--- a/src/cli/effects/execute.ts
+++ b/src/cli/effects/execute.ts
@@ -3,6 +3,13 @@ import type { StepDef } from "../state/types";
 import { executeIntent, getSmartAccountAddress } from "@/lib/execute";
 import { validateNoDuplicate, updateTransactionStatus } from "@/lib/idempotency";
 import { getIntentAmountETH } from "@/lib/policy/checker";
+import {
+  getIntentChainId,
+  requestChainSwitch,
+  switchWalletChain,
+  waitForChainPropagation
+} from "@/lib/chain-utils";
+import { getChainConfig } from "@/lib/chains/registry";
 
 export const executePrivyFx: StepDef["onEnter"] = async (ctx, core, dispatch, signal) => {
   console.log("🔍 Execute effect - Full context:", {
@@ -51,6 +58,108 @@ export const executePrivyFx: StepDef["onEnter"] = async (ctx, core, dispatch, si
     });
     return;
   }
+
+  // ============================================================================
+  // CHAIN SYNCHRONIZATION LOGIC
+  // ============================================================================
+
+  let targetChainId: number;
+  try {
+    targetChainId = getIntentChainId(ctx.norm);
+  } catch (error) {
+    dispatch({
+      type: "EXEC.FAIL",
+      error: {
+        code: "INVALID_CHAIN",
+        message: "Cannot determine target chain for transaction",
+        phase: "execute",
+      },
+    });
+    return;
+  }
+
+  const targetChainConfig = getChainConfig(targetChainId);
+  if (!targetChainConfig) {
+    dispatch({
+      type: "EXEC.FAIL",
+      error: {
+        code: "CHAIN_CONFIG_MISSING",
+        message: `Chain configuration not found for chain ${targetChainId}`,
+        phase: "execute",
+      },
+    });
+    return;
+  }
+
+  // Check if chain switch is needed
+  const needsChainSwitch = core.chainId !== targetChainId;
+
+  if (needsChainSwitch) {
+    const currentChain = getChainConfig(core.chainId);
+
+    console.log(`🔄 Chain switch required: ${currentChain?.name || core.chainId} → ${targetChainConfig.name || targetChainId}`);
+
+    // Notify user about chain switch
+    dispatch({
+      type: "CHAT.ADD",
+      message: {
+        role: "assistant",
+        content: `🔄 Switching chains: ${currentChain?.name || core.chainId} → ${targetChainConfig.name}...`,
+        timestamp: Date.now(),
+      },
+    });
+
+    // 1. Request chain switch in application state
+    const chainSwitchSuccess = await requestChainSwitch(targetChainId);
+
+    if (!chainSwitchSuccess) {
+      dispatch({
+        type: "EXEC.FAIL",
+        error: {
+          code: "CHAIN_SWITCH_FAILED",
+          message: `Failed to switch to ${targetChainConfig.name} (${targetChainId})`,
+          phase: "execute",
+        },
+      });
+      return;
+    }
+
+    console.log(`✅ Application chain state switched to ${targetChainId}`);
+
+    // 2. Switch wallet chain if in EOA mode
+    if (accountMode === "EOA" && core.selectedWallet) {
+      const walletSwitchResult = await switchWalletChain(
+        core.selectedWallet,
+        targetChainId
+      );
+
+      if (walletSwitchResult.success) {
+        console.log(`✅ Wallet chain switched to ${targetChainId}`);
+      } else {
+        // Log warning but continue - some embedded wallets may not need explicit switching
+        console.warn(`⚠️ Wallet chain switch warning (may not be critical): ${walletSwitchResult.error}`);
+      }
+    }
+
+    // 3. Wait for state propagation
+    await waitForChainPropagation(500);
+
+    // 4. Confirm user about successful switch
+    dispatch({
+      type: "CHAT.ADD",
+      message: {
+        role: "assistant",
+        content: `✅ Switched to ${targetChainConfig.name}`,
+        timestamp: Date.now(),
+      },
+    });
+  } else {
+    console.log(`✅ Already on correct chain: ${targetChainId}`);
+  }
+
+  // ============================================================================
+  // END: CHAIN SYNCHRONIZATION LOGIC
+  // ============================================================================
 
   let promptId: string | undefined;
 

--- a/src/lib/chain-utils.ts
+++ b/src/lib/chain-utils.ts
@@ -1,0 +1,78 @@
+// Chain synchronization utilities for transaction flows
+
+import { getChainConfig } from "@/lib/chains/registry";
+import type { NormalizedIntent } from "@/lib/normalize";
+
+/**
+ * Extract target chain ID from normalized intent
+ */
+export function getIntentChainId(norm: NormalizedIntent): number {
+  if ('chainId' in norm) {
+    return norm.chainId;
+  }
+  if ('fromChainId' in norm) {
+    return norm.fromChainId;
+  }
+  throw new Error('Cannot determine chain ID from normalized intent');
+}
+
+/**
+ * Request chain switch via custom event
+ * Returns promise that resolves when switch completes
+ */
+export async function requestChainSwitch(targetChainId: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    window.dispatchEvent(new CustomEvent('chain-switch-request', {
+      detail: { chainId: targetChainId, resolve }
+    }));
+  });
+}
+
+/**
+ * Switch wallet chain for EOA mode
+ * Swallows errors for wallets that don't support switching
+ */
+export async function switchWalletChain(
+  wallet: any,
+  targetChainId: number
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await wallet.switchChain(targetChainId);
+    return { success: true };
+  } catch (error: any) {
+    const errorMessage = error?.message || 'Unknown error';
+    console.warn(`Wallet chain switch warning: ${errorMessage}`);
+    return {
+      success: false,
+      error: errorMessage
+    };
+  }
+}
+
+/**
+ * Wait for state propagation after chain switch
+ */
+export async function waitForChainPropagation(ms: number = 300): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Verify chain consistency before transaction
+ */
+export function verifyChainConsistency(
+  currentChainId: number,
+  targetChainId: number,
+  context: string
+): { consistent: boolean; warning?: string } {
+  if (currentChainId !== targetChainId) {
+    const currentChain = getChainConfig(currentChainId);
+    const targetChain = getChainConfig(targetChainId);
+
+    return {
+      consistent: false,
+      warning: `${context}: Chain mismatch detected (current: ${currentChain?.name || currentChainId}, target: ${targetChain?.name || targetChainId})`
+    };
+  }
+
+  return { consistent: true };
+}

--- a/src/lib/normalize.ts
+++ b/src/lib/normalize.ts
@@ -370,7 +370,8 @@ export async function normalizeTransferIntent(
   const selectedToken = (intent as any)._selectedToken;
 
   // Use the token's chainId if available, otherwise resolve from intent.chain
-  const chainId = selectedToken?.chainId ?? opts?.preferredChainId ?? resolveChainForNormalization(intent.chain);
+  // Priority: 1) selected token chain, 2) intent chain, 3) preferred chain from context
+  const chainId = selectedToken?.chainId ?? resolveChainForNormalization(intent.chain) ?? opts?.preferredChainId;
 
   // Validate chain is supported
   if (!isChainSupported(chainId)) {


### PR DESCRIPTION
Add automatic chain switching when transaction arguments specify a different chain than currently selected.

Changes:
- Add chain utils module with helper functions
- Auto-switch chains before transaction execution
- Show user warning when chain switch will occur
- Fix transfer intent to respect explicit chain argument

Fixes transactions failing when user specifies different chain in command (e.g., "swap on ethereum" while on Base).